### PR TITLE
Through crack

### DIFF
--- a/self_drive/src/self_drive.py
+++ b/self_drive/src/self_drive.py
@@ -19,7 +19,7 @@ class SelfDrive:
         if scan.ranges[45] < 0.2828 and scan.ranges[45] != 0:
             turtle_vel.linear.x = 0
             turtle_vel.angular.z = 2.5
-        if scan.ranges[0] > 0.25 and scan.ranges[0] != 0:
+        if scan.ranges[0] > 0.25 and scan.ranges[0] != 0 and scan.ranges[45] > 0.14:
             turtle_vel.linear.x = 0.15
             turtle_vel.angular.z = 0
         self.publisher.publish(turtle_vel)

--- a/self_drive/src/self_drive.py
+++ b/self_drive/src/self_drive.py
@@ -19,6 +19,9 @@ class SelfDrive:
         if scan.ranges[45] < 0.2828 and scan.ranges[45] != 0:
             turtle_vel.linear.x = 0
             turtle_vel.angular.z = 2.5
+        if scan.ranges[0] > 0.25 and scan.ranges[0] != 0:
+            turtle_vel.linear.x = 0.15
+            turtle_vel.angular.z = 0
         self.publisher.publish(turtle_vel)
 
 def main():


### PR DESCRIPTION
옆으로 이동하는 부분만 작동할 경우, 앞에 공간이 있음에도 불구하고 제자리에서 뱅글 뱅글 도는 현상이 발생하였습니다. 따라서 원래 코드는 그대로 두고, 나중에 앞에 공간이 있을 경우, 옆으로 이동하는 부분에 대하여 앞의 코드가 꼬이지 않을 범위를 지정하였습니다. 그러나 이렇게 할 경우, 옆으로 이동하는 함수를 실행하는 부분에 오류가 너무 크게 나타나서 벽을 밀고가는 경우가 발생하였습니다. 그 오류를 수정하기 위해서 값을 2부터 0.25단위로 내려가면서 측정하였더니 1.25가 가장 이상적인 경로를 그려서 그 값을 45도에 대한 거리값으로 지정하였습니다.